### PR TITLE
enable loading from global scripts dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,18 @@ A fully-featured port of [SponsorBlock](https://github.com/ajayyy/SponsorBlock) 
 - Python 3
 
 ## Installation
-Move `sponsorblock.lua` and `sponsorblock_shared` into your mpv `scripts` folder.
+Move `sponsorblock.lua` and `sponsorblock_shared` into your mpv `scripts` folder under a `sponsorblock` directory:
 ```
 mpv/scripts/
-├── sponsorblock.lua
-└── sponsorblock_shared
+├── sponsorblock/
     ├── main.lua
-    └── sponsorblock.py
+    ├── sponsorblock.lua
+    └── sponsorblock_shared
+        ├── main.lua
+        └── sponsorblock.py
 ```
+
+The easiest way is to download the [ZIP file](https://github.com/po5/mpv_sponsorblock/archive/refs/heads/master.zip) and unpack it into the correct location.
 
 ## Usage
 Play a YouTube video, sponsors will be skipped automatically.

--- a/main.lua
+++ b/main.lua
@@ -1,0 +1,1 @@
+sponsorblock.lua

--- a/sponsorblock.lua
+++ b/sponsorblock.lua
@@ -92,7 +92,7 @@ end
 options.local_database = false
 
 local utils = require "mp.utils"
-scripts_dir = mp.find_config_file("scripts")
+scripts_dir = mp.get_script_directory()
 
 local sponsorblock = utils.join_path(scripts_dir, "sponsorblock_shared/sponsorblock.py")
 local uid_path = utils.join_path(scripts_dir, "sponsorblock_shared/sponsorblock.txt")


### PR DESCRIPTION
the scripts_dir detection logic uses `mp.find_config_file("scripts")` which returns `$XDG_CONFIG_HOME/mpv/scripts` even if the plugin is installed globally under `/etc/mpv/scripts`.

fix this by using `mp.get_script_directory()`, which requires the install the plugin in a `script directory`, but that is recommended anyway for plugins like this one: https://mpv.io/manual/master/#script-location